### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Provides various methods for providing a smoothed input from a sensor.
 category=Data Processing
 url=https://github.com/MattFryer/Smoothed
 architectures=*
-includes=Board_Identify.h
+includes=Smoothed.h


### PR DESCRIPTION
The previous `includes` value: `Board_Identify.h` looks like it was a copy/paste error from a different library.