### PR TITLE
attempt to fix overflow error in get()

### DIFF
--- a/examples/Smoothed/Smoothed.ino
+++ b/examples/Smoothed/Smoothed.ino
@@ -16,7 +16,8 @@
 
 // Create two instances of the class to use. 
 Smoothed <float> mySensor; 
-Smoothed <float> mySensor2; 			
+Smoothed <float> mySensor2;
+Smoothed <uint16_t> syntheticExample;
 
 /* We are using a template class that can be used with any numeric data type. 
    You can therefore replace <float> above with any other data type to suit your sensor readings and desired accuracy. 
@@ -49,6 +50,8 @@ void setup() {
 	   The default parameters are SMOOTHED_EXPONENTIAL and 10.
 	*/
 
+	syntheticExample.begin(SMOOTHED_AVERAGE, 10);
+
     // Although it is unnecessary here, the stored values can be cleared if needed.
     mySensor.clear();
 }
@@ -59,14 +62,17 @@ void loop() {
     
     // Add the new value to both sensor value stores
     mySensor.add(currentSensorValue);
-    mySensor2.add(currentSensorValue);   
+    mySensor2.add(currentSensorValue);
+	syntheticExample.add(64000);
     
     // Get the smoothed values
     float smoothedSensorValueAvg = mySensor.get();
-    float smoothedSensorValueExp = mySensor2.get();	  
+    float smoothedSensorValueExp = mySensor2.get();
+	uint16_t smoothedSyntheticExample = syntheticExample.get();
     
     // Output the smoothed values to the serial stream. Open the Arduino IDE Serial plotter to see the effects of the smoothing methods.
-    Serial.print(currentSensorValue); Serial.print("\t"); Serial.print(smoothedSensorValueAvg); Serial.print("\t"); Serial.println(smoothedSensorValueExp);
+    Serial.print(currentSensorValue); Serial.print("\t"); Serial.print(smoothedSensorValueAvg); Serial.print("\t"); Serial.print(smoothedSensorValueExp); Serial.print("\t"); Serial.println(smoothedSyntheticExample);
+	
     
     // If needed we can also return the last stored value which will be unsmoothed
     float lastValueStoredAvg = mySensor.getLast();

--- a/examples/Smoothed/Smoothed.ino
+++ b/examples/Smoothed/Smoothed.ino
@@ -17,7 +17,6 @@
 // Create two instances of the class to use. 
 Smoothed <float> mySensor; 
 Smoothed <float> mySensor2;
-Smoothed <uint16_t> syntheticExample;
 
 /* We are using a template class that can be used with any numeric data type. 
    You can therefore replace <float> above with any other data type to suit your sensor readings and desired accuracy. 
@@ -50,8 +49,6 @@ void setup() {
 	   The default parameters are SMOOTHED_EXPONENTIAL and 10.
 	*/
 
-	syntheticExample.begin(SMOOTHED_AVERAGE, 10);
-
     // Although it is unnecessary here, the stored values can be cleared if needed.
     mySensor.clear();
 }
@@ -63,12 +60,10 @@ void loop() {
     // Add the new value to both sensor value stores
     mySensor.add(currentSensorValue);
     mySensor2.add(currentSensorValue);
-	syntheticExample.add(64000);
     
     // Get the smoothed values
     float smoothedSensorValueAvg = mySensor.get();
     float smoothedSensorValueExp = mySensor2.get();
-	uint16_t smoothedSyntheticExample = syntheticExample.get();
     
     // Output the smoothed values to the serial stream. Open the Arduino IDE Serial plotter to see the effects of the smoothing methods.
     Serial.print(currentSensorValue); Serial.print("\t"); Serial.print(smoothedSensorValueAvg); Serial.print("\t"); Serial.print(smoothedSensorValueExp); Serial.print("\t"); Serial.println(smoothedSyntheticExample);

--- a/examples/Smoothed/Smoothed.ino
+++ b/examples/Smoothed/Smoothed.ino
@@ -66,7 +66,7 @@ void loop() {
     float smoothedSensorValueExp = mySensor2.get();
     
     // Output the smoothed values to the serial stream. Open the Arduino IDE Serial plotter to see the effects of the smoothing methods.
-    Serial.print(currentSensorValue); Serial.print("\t"); Serial.print(smoothedSensorValueAvg); Serial.print("\t"); Serial.print(smoothedSensorValueExp); Serial.print("\t"); Serial.println(smoothedSyntheticExample);
+    Serial.print(currentSensorValue); Serial.print("\t"); Serial.print(smoothedSensorValueAvg); Serial.print("\t"); Serial.println(smoothedSensorValueExp);
 	
     
     // If needed we can also return the last stored value which will be unsmoothed

--- a/src/Smoothed.h
+++ b/src/Smoothed.h
@@ -15,14 +15,14 @@ template <typename T>
 class Smoothed {
   private:
     byte smoothMode;
-    byte smoothReadingsFactor = 10; // The smoothing factor. In avergare mode, this is the number of readings to average. 
-    byte smoothReadingsPosition = 0; // Current position in the array
-    byte smoothReadingsNum = 0; // Number of readings currently being averaged
+    uint16_t smoothReadingsFactor = 10; // The smoothing factor. In average mode, this is the number of readings to average. 
+    uint16_t smoothReadingsPosition = 0; // Current position in the array
+    uint16_t smoothReadingsNum = 0; // Number of readings currently being averaged
     T *smoothReading; // Array of readings
   public:
     Smoothed();
     ~Smoothed(); // Destructor to clean up when class instance killed
-    bool begin (byte smoothMode, byte smoothFactor = 10);
+    bool begin (byte smoothMode, uint16_t smoothFactor = 10);
     bool add (T newReading);
     T get ();
     T getLast ();
@@ -43,7 +43,7 @@ Smoothed<T>::~Smoothed () { // Destructor
 
 // Inintialise the array for storing sensor values
 template <typename T>
-bool Smoothed<T>::begin (byte mode, byte smoothFactor) { 
+bool Smoothed<T>::begin (byte mode, uint16_t smoothFactor) { 
   smoothMode = mode;
   smoothReadingsFactor = smoothFactor; 
   

--- a/src/Smoothed.h
+++ b/src/Smoothed.h
@@ -121,12 +121,20 @@ T Smoothed<T>::get () {
   switch (smoothMode) {
     case SMOOTHED_AVERAGE : { // SMOOTHED_AVERAGE
       T runningTotal = 0;
-    
+      // calculating a `SUM(smoothReadings) / smoothReadingsNum` can lead to overflows.
+      T tmpRes = 0;
+      T remainder = 0;
       for (int x = 0; x < smoothReadingsNum; x++) {
-        runningTotal += smoothReading[x];
+        tmpRes = smoothReading[x] / smoothReadingsNum;
+        remainder += smoothReading[x] - tmpRes * smoothReadingsNum;
+        runningTotal += tmpRes;
+        if (remainder > smoothReadingsNum) {
+          tmpRes = remainder / smoothReadingsNum;
+          remainder -= tmpRes * smoothReadingsNum;
+          runningTotal += tmpRes;
+        }
       }
-      
-      return runningTotal / smoothReadingsNum;
+      return runningTotal;
     }
       break;
 


### PR DESCRIPTION
The average calculated as "SUM(values) / NUM(values)" can lead to an overflow error if the values themselves or the number of values are big. 

This patch divides the values by the number of values first, then sums them up. Potentially this sacrifices some precision for the benefit of avoiding an overflow error in most (but not all) cases.

This problem is particularly visible for smaller data types such as `int16_t`, so possibly the issue #5 is related. I added an example that should fail to the Smoothed.ino (but I can't test that part right now).