### PR TITLE
Fixed: control reaches end of non-void function

### DIFF
--- a/src/Smoothed.h
+++ b/src/Smoothed.h
@@ -195,5 +195,6 @@ bool Smoothed<T>::clear () {
     default : 
       return false;
       break;
-  }         
+  }
+  return false;
 }


### PR DESCRIPTION
Fixes this compiler warning
```
Smoothed.h: In member function 'bool Smoothed<T>::clear() [with T = short unsigned int]':
Smoothed.h:199:1: warning: control reaches end of non-void function [-Wreturn-type]
```